### PR TITLE
fix: use fs error types to make things api-compatible

### DIFF
--- a/memfs_test.go
+++ b/memfs_test.go
@@ -1,6 +1,7 @@
 package memfs
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"testing"
@@ -41,12 +42,12 @@ func TestMemFS(t *testing.T) {
 	}
 
 	err = rootFS.WriteFile("foo/baz/buz.txt", []byte("buz"), 0777)
-	if err == nil {
+	if err == nil && errors.Is(err, fs.ErrNotExist) {
 		t.Fatalf("Expected missing directory error but got none")
 	}
 
 	_, err = fs.ReadFile(rootFS, "foo/baz/buz.txt")
-	if err == nil {
+	if err == nil && errors.Is(err, fs.ErrNotExist) {
 		t.Fatal("Expected no such file but got no error")
 	}
 


### PR DESCRIPTION
Make it more compatible with `fs.FS` by returning the same errors as `os.DirFS` when possible (basically wrapping errors with `fs` error types).

It should now be possible to do things like:

```go
info, err := fs.Stat(fs, path)
if errors.Is(err, fs.ErrNotExist) {
  // etc
}
```