### PR TITLE
Add writes to the File type

### DIFF
--- a/memfs.go
+++ b/memfs.go
@@ -349,6 +349,13 @@ func (f *File) Read(b []byte) (int, error) {
 	return f.content.Read(b)
 }
 
+func (f *File) Write(b []byte) (int, error) {
+	if f.closed {
+		return 0, fs.ErrClosed
+	}
+	return f.content.Write(b)
+}
+
 func (f *File) Close() error {
 	if f.closed {
 		return fs.ErrClosed


### PR DESCRIPTION
Simple change to add writes to the File type, to allow appending data instead of obliterating to named files.