### PR TITLE
Implement io.SubFS interface

### DIFF
--- a/memfs.go
+++ b/memfs.go
@@ -247,6 +247,15 @@ func (rootFS *FS) Open(name string) (fs.File, error) {
 	return nil, fmt.Errorf("unexpected file type in fs: %s: %w", name, fs.ErrInvalid)
 }
 
+// Sub returns an FS corresponding to the subtree rooted at path.
+func (rootFS *FS) Sub(path string) (fs.FS, error) {
+	dir, err := rootFS.getDir(path)
+	if err != nil {
+		return nil, err
+	}
+	return &FS{dir: dir}, nil
+}
+
 type dir struct {
 	mu       sync.Mutex
 	name     string

--- a/memfs_test.go
+++ b/memfs_test.go
@@ -66,6 +66,20 @@ func TestMemFS(t *testing.T) {
 		t.Fatalf("write/read baz.txt mismatch %s", diff)
 	}
 
+	subFS, err := rootFS.Sub("foo/bar")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gotSubBody, err := fs.ReadFile(subFS, "baz.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(body, gotSubBody); diff != "" {
+		t.Fatalf("write/read baz.txt mismatch %s", diff)
+	}
+
 	body = []byte("top_level_file")
 	err = rootFS.WriteFile("top_level_file.txt", body, 0777)
 	if err != nil {


### PR DESCRIPTION
This PR implements the io.SubFS interface so that the `fs.FS` returned from `fs.Sub` can still be cast back to `*memfs.FS`.